### PR TITLE
Fix input clearing in economic factors

### DIFF
--- a/src/components/EconomicFactors.tsx
+++ b/src/components/EconomicFactors.tsx
@@ -8,12 +8,10 @@ const EconomicFactors: React.FC = () => {
 
   const handleChange = (factor: keyof typeof economicFactors, value: string) => {
     const numValue = parseFloat(value);
-    if (!isNaN(numValue)) {
-      setEconomicFactors({
-        ...economicFactors,
-        [factor]: numValue
-      });
-    }
+    setEconomicFactors({
+      ...economicFactors,
+      [factor]: isNaN(numValue) ? 0 : numValue
+    });
   };
 
   const timeToFire = calculateTimeToFire();


### PR DESCRIPTION
## Summary
- allow clearing inputs in `EconomicFactors` component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683d62ff11788327857dd8e401678759